### PR TITLE
Log error when a metric isn't found instead of breaking

### DIFF
--- a/redis_info.py
+++ b/redis_info.py
@@ -116,7 +116,11 @@ class RedisCollector():
                                'counter',
                                type_instance='commands_processed')
             else:
-                self.dispatch_value(info[key], mtype, type_instance=key)
+                try:
+                    self.dispatch_value(info[key], mtype, type_instance=key)
+                except KeyError:
+                    collectd.error("Metric %s not found in Redis INFO output" % key)
+                    continue
 
     def dispatch_list_lengths(self, client):
         """


### PR DESCRIPTION
When you first start up a redis instance, db0 doesn't exist and won't report anything in the INFO output.