### PR TITLE
Converting up and ok string values to integers.

### DIFF
--- a/redis_info.py
+++ b/redis_info.py
@@ -160,6 +160,14 @@ class RedisCollector:
             value = int(value)
         except ValueError:
             value = float(value)
+        except ValueError:
+            if type(value) == str:
+                if value in ["up", "ok"]:
+                    value = 1
+                else:
+                    value = 0
+            else:
+                raise ValueError
 
         self.log_verbose("Sending value: %s=%s (%s)" % (type_instance, value, dimensions))
 


### PR DESCRIPTION
Hello there,
I stumbled into a ValueError when parsing value for `master_link_status` ("up" or "down") :

> Traceback (most recent call last):\n\n  File \"/collectd-python/redis/redis_info.py\", line 160, in dispatch_value\n    value = int(value)\n\nValueError: invalid literal for int() with base 10: 'up'\n\n\nDuring handling of the above exception, another exception occurred:\n\n\nTraceback (most recent call last):\n\n  File \"/lib/python3.8/site-packages/sfxrunner/scheduler/simple.py\", line 50, in _call_on_interval\n    func()\n\n  File \"/collectd-python/redis/redis_info.py\", line 186, in read_callback\n    self.get_metrics()\n\n  File \"/collectd-python/redis/redis_info.py\", line 198, in get_metrics\n    self.dispatch_info(client)\n\n  File \"/collectd-python/redis/redis_info.py\", line 113, in dispatch_info\n    self.dispatch_value(info[key], mtype, type_instance=key)\n\n  File \"/collectd-python/redis/redis_info.py\", line 162, in dispatch_value\n    value = float(value)\n\nValueError: could not convert string to float: 'up'\n" createdTime=1.598430934323102e+09 lineno=56 logger=root monitorID=5 monitorType=collectd/redis runnerPID=28 sourcePath=/lib/python3.8/site-packages/sfxrunner/logs.py

So I wrote this little piece of code to handle "up", and "ok" too, for metrics such as _aof_last_bgrewrite_status_ or _aof_last_write_status_. Not sure this is the most elegant way of doing this, or if it should be placed somewhere else (dispatch_info maybe?). I'll let it to you.
