### PR TITLE
set max split to 1

### DIFF
--- a/redis_info.py
+++ b/redis_info.py
@@ -74,7 +74,7 @@ class RedisCollector:
                 collectd.warning("redis_info plugin: Bad format for info line: %s" % line)
                 continue
 
-            key, val = line.split(":")
+            key, val = line.split(":", 1)
 
             # Handle multi-value keys (for dbs and slaves).
             # db lines look like "db0:keys=10,expire=0"


### PR DESCRIPTION
Signed-off-by: Dani Louca <dlouca@splunk.com>

This is a valid line in info and currently results of `line 77, in parse_info\n key, val = line.split(\":\")\n\nValueError: too many values to unpack (expected 2)`
```
master0:name=mymaster,status=ok,address=x.x.x.x:6379,slaves=2,sentinels=4
```