### PR TITLE
fix master link status 

### DIFF
--- a/redis_info.py
+++ b/redis_info.py
@@ -159,7 +159,17 @@ class RedisCollector:
         try:
             value = int(value)
         except ValueError:
-            value = float(value)
+            try: 
+                value = float(value)
+            except ValueError:
+                if type_instance == "master_link_status":
+                    if value == "up":
+                        value = 1
+                    else:
+                        value = 0
+                else:
+                    collectd.warning("redis_info plugin: could not cast value %s for instance %s " % (value, type_instance))
+                    return
 
         self.log_verbose("Sending value: %s=%s (%s)" % (type_instance, value, dimensions))
 


### PR DESCRIPTION
A regression was introduced with this commit https://github.com/signalfx/signalfx-agent/commit/7ef80a77bd139a64d2a17a20530e73de56ebba43

```gauge.master_link_status``` on this info output (this is the replica node)

````
# Replication
role:slave
master_host:redis-primary
master_port:6379
master_link_status:up
master_last_io_seconds_ago:3
master_sync_in_progress:0
slave_repl_offset:15596
slave_priority:100
slave_read_only:1
replica_announced:1
connected_slaves:0
master_failover_state:no-failover
master_replid:ff561e6ce99d965b6f19ae5c3bb0316cfc069b5f
master_replid2:0000000000000000000000000000000000000000
master_repl_offset:15596
second_repl_offset:-1
repl_backlog_active:1
repl_backlog_size:1048576
repl_backlog_first_byte_offset:1
repl_backlog_histlen:15596
````

will fail the cast
````
line 162, in dispatch_value\n value = float(value)\n\nValueError: could not convert string to float: 'up'\n"
````

This fix translate the up to 1 and down(everything else) to 0.
Also catches any other cast exception so we don't crash the monitor.

cc: @jrcamp @keitwb

Signed-off-by: Dani Louca <dlouca@splunk.com>